### PR TITLE
Fixed export change from jsbn (was window.BigInteger, is now window.jsbn.BigInteger)

### DIFF
--- a/money.js
+++ b/money.js
@@ -9,8 +9,8 @@
         var BigInteger = require("jsbn");
         factory(root, exports, BigInteger);
     } else {
-        var BigInteger = root.BigInteger ? root.BigInteger : root.jsbn.BigInteger;
-        root.Money = factory(root, {}, BigInteger);
+        var BigInt = root.BigInteger ? root.BigInteger : root.jsbn.BigInteger;
+        root.Money = factory(root, {}, BigInt);
     }
 }(function (root, Money, BigInteger) {
     "use strict";

--- a/money.js
+++ b/money.js
@@ -9,7 +9,7 @@
         var BigInteger = require("jsbn");
         factory(root, exports, BigInteger);
     } else {
-        var BigInteger = root.BigInteger ? rootBigInteger : root.jsbn.BigInteger;
+        var BigInteger = root.BigInteger ? root.BigInteger : root.jsbn.BigInteger;
         root.Money = factory(root, {}, BigInteger);
     }
 }(function (root, Money, BigInteger) {

--- a/money.js
+++ b/money.js
@@ -9,7 +9,8 @@
         var BigInteger = require("jsbn");
         factory(root, exports, BigInteger);
     } else {
-        root.Money = factory(root, {}, root.jsbn.BigInteger);
+        var BigInteger = root.BigInteger ? rootBigInteger : root.jsbn.BigInteger;
+        root.Money = factory(root, {}, BigInteger);
     }
 }(function (root, Money, BigInteger) {
     "use strict";

--- a/money.js
+++ b/money.js
@@ -9,7 +9,7 @@
         var BigInteger = require("jsbn");
         factory(root, exports, BigInteger);
     } else {
-        root.Money = factory(root, {}, root.BigInteger);
+        root.Money = factory(root, {}, root.jsbn.BigInteger);
     }
 }(function (root, Money, BigInteger) {
     "use strict";


### PR DESCRIPTION
https://github.com/andyperlitch/jsbn/pull/7

That pull request changed the export object. That breaks money-math (at least for those using the global browser solution). This pull-request should fix that.