### PR TITLE
Added full support for negative float in floatToAmount

### DIFF
--- a/money.js
+++ b/money.js
@@ -116,9 +116,11 @@
     };
 
     Money.floatToAmount = function (f) {
-        return ("" + Math.round(f * 100.0) / 100.0)
-            .replace(/^(\d+)$/, "$1.00")
-            .replace(/^(\d+)\.(\d)$/, "$1.$20");
+        return ("" + (Math.round(f * 100.0) / 100.0))
+        .replace(/^-(\d+)$/, "-$1.00")              //-xx
+        .replace(/^(\d+)$/, "$1.00")                //xx
+        .replace(/^-(\d+)\.(\d)$/, "-$1.$20")       //-xx.xx
+        .replace(/^(\d+)\.(\d)$/, "$1.$20");        //xx.xx
     };
 
     Money.integralPart = function (amount) {

--- a/spec/money.spec.js
+++ b/spec/money.spec.js
@@ -208,16 +208,28 @@
     });
 
     describe("money.floatToAmount()", function () {
-        it("it converts a float with 2-digit fractional part to string", function () {
+        it("it converts a positive float with 2-digit fractional part to string", function () {
             assert.strictEqual(money.floatToAmount(11.12), "11.12");
         });
 
-        it("it appends '.00' to a whole number", function () {
+        it("it appends '.00' to a whole positive number", function () {
             assert.strictEqual(money.floatToAmount(56), "56.00");
         });
 
-        it("it appends '.0' to a number with 1-digit fraction", function () {
+        it("it appends '.0' to a positive number with 1-digit fraction", function () {
             assert.strictEqual(money.floatToAmount(56.3), "56.30");
+        });
+
+        it("it converts a negative float with 2-digit fractional part to string", function () {
+            assert.strictEqual(money.floatToAmount(-11.12), "-11.12");
+        });
+
+        it("it appends '.00' to a whole negative number", function () {
+            assert.strictEqual(money.floatToAmount(-56), "-56.00");
+        });
+
+        it("it appends '.0' to a negative number with 1-digit fraction", function () {
+            assert.strictEqual(money.floatToAmount(-56.3), "-56.30");
         });
 
         it("rounds up a long-fraction number A", function () {


### PR DESCRIPTION
For issue #18.

Added 3 new unit test since it wasn't tested !
```
...
money.floatToAmount()
    √ it converts a positive float with 2-digit fractional part to string
    √ it appends '.00' to a whole positive number
    √ it appends '.0' to a positive number with 1-digit fraction
    √ it converts a negative float with 2-digit fractional part to string <---
    √ it appends '.00' to a whole negative number <---
    √ it appends '.0' to a negative number with 1-digit fraction <---
    √ rounds up a long-fraction number A
    √ rounds up a long-fraction number B
    √ rounds up a long-fraction number C
    √ rounds up a long-fraction number D
    √ rounds up a long-fraction number E
...
72 passing (85ms)
```