### PR TITLE
Remove unnecessary 0 on start of cents in amountToCents function

### DIFF
--- a/money.js
+++ b/money.js
@@ -94,7 +94,7 @@
     };
 
     Money.amountToCents = function (amount) {
-        return amount.replace(".", "");
+        return amount.replace(".", "").replace(/^0+/, "");
     };
 
     Money.centsToAmount = function (cents) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-math",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "jsbn-based arbitrary precision operations on currency amounts \"XXX.YY\"; because floats are BAD for representing money",
   "main": "money.js",
   "scripts": {

--- a/spec/money.spec.js
+++ b/spec/money.spec.js
@@ -12,6 +12,10 @@
         it("works on negative amount", function () {
             assert.strictEqual(money.amountToCents("-10001.00"), "-1000100");
         });
+
+        it("works on just cents, removes 0 from start", function () {
+            assert.strictEqual(money.amountToCents("0.99"), "99");
+        });
     });
 
     describe("money.centsToAmount()", function () {


### PR DESCRIPTION
amountToCents for numbers like "0.99" should return "99" instead of "099".